### PR TITLE
:package: 2.1.7 Release

### DIFF
--- a/Carter Games/Save Manager/Code/Editor/Custom Editors/Windows/Editor Window/Sub Windows/EditorTab.cs
+++ b/Carter Games/Save Manager/Code/Editor/Custom Editors/Windows/Editor Window/Sub Windows/EditorTab.cs
@@ -145,8 +145,7 @@ namespace CarterGames.Assets.SaveManager.Editor.SubWindows
 
                     foreach (var saveObject in saveObjectsInCategory)
                     {
-                        if (saveObject.GetType().FullName == DemoSaveObjectFullName)
-                            continue;
+                        if (saveObject.GetType().FullName == DemoSaveObjectFullName) continue;
                         DrawSaveObjectEditor(saveObject);
                     }
                 }

--- a/Carter Games/Save Manager/Code/Editor/Utility/AssetVersionData.cs
+++ b/Carter Games/Save Manager/Code/Editor/Utility/AssetVersionData.cs
@@ -31,7 +31,7 @@ namespace CarterGames.Assets.SaveManager.Editor
         /// <summary>
         /// The version number of the asset.
         /// </summary>
-        public static string VersionNumber => "2.1.6";
+        public static string VersionNumber => "2.1.7";
         
         
         /// <summary>
@@ -40,6 +40,6 @@ namespace CarterGames.Assets.SaveManager.Editor
         /// <remarks>
         /// Asset owner is in the UK, so its D/M/Y format.
         /// </remarks>
-        public static string ReleaseDate => "07/05/2024";
+        public static string ReleaseDate => "11/05/2024";
     }
 }

--- a/Carter Games/Save Manager/Code/Runtime/Save Data/Objects/SaveObject.cs
+++ b/Carter Games/Save Manager/Code/Runtime/Save Data/Objects/SaveObject.cs
@@ -130,6 +130,7 @@ namespace CarterGames.Assets.SaveManager
             
             foreach (var t in saveValues)
             {
+                if (t == null) continue;
                 if (!t.GetType().IsSubclassOf(typeof(SaveValueBase))) continue;
                 var sv = (SaveValueBase)t;
                 if (!data.ContainsKey(sv.key)) continue;
@@ -168,6 +169,7 @@ namespace CarterGames.Assets.SaveManager
             
             for (var i = 0; i < saveValues.Length; i++)
             {
+                if (saveValues[i] == null) continue;
                 if (!saveValues[i].GetType().IsSubclassOf(typeof(SaveValueBase))) continue;
                 var sv = (SaveValueBase) saveValues[i];
                 dic.Add(sv.key, sv);


### PR DESCRIPTION
- Fixed a null ref from the save editor tab window when editing values (probs from the last release).