### PR TITLE
:package: 2.3.7 Hotfix Release

### DIFF
--- a/Carter Games/Save Manager/Code/Editor/Info/AssetVersionData.cs
+++ b/Carter Games/Save Manager/Code/Editor/Info/AssetVersionData.cs
@@ -31,7 +31,7 @@ namespace CarterGames.Assets.SaveManager.Editor
         /// <summary>
         /// The version number of the asset.
         /// </summary>
-        public static string VersionNumber => "2.3.6";
+        public static string VersionNumber => "2.3.7";
         
         
         /// <summary>
@@ -40,6 +40,6 @@ namespace CarterGames.Assets.SaveManager.Editor
         /// <remarks>
         /// Asset owner is in the UK, so its Y/M/D format.
         /// </remarks>
-        public static string ReleaseDate => "2025/03/12";
+        public static string ReleaseDate => "2025/07/13";
     }
 }

--- a/Carter Games/Save Manager/Code/Runtime/Save Data/Values/SaveValue.cs
+++ b/Carter Games/Save Manager/Code/Runtime/Save Data/Values/SaveValue.cs
@@ -106,7 +106,6 @@ namespace CarterGames.Assets.SaveManager
         public SaveValue(string key, T value)
         {
             this.key = key;
-            this.value = value;
             defaultValue = value;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "games.carter.savemanager",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "displayName": "Save Manager",
   "description": "A free, scriptable object based, local save system for Unity. Works on all platforms using standard JSON Utility.",
   "unity": "2020.3",


### PR DESCRIPTION
- A small update to fix an issue where default values on a save object would get assigned to save values in the editor on a script reload. Not game breaking, but annoying to work with in the editor. Only happened if the save value had a default value assigned to it.