### PR TITLE
🔧 Hotfix for art setup in package manager version of 3.x

### DIFF
--- a/Code/Editor/Art/EditorArtHandler.cs
+++ b/Code/Editor/Art/EditorArtHandler.cs
@@ -53,8 +53,17 @@ namespace CarterGames.Assets.SaveManager.Editor
         /// <returns></returns>
         private static string GetPathToAsset(string pathEnd)
         {
-            var basePath = Path.GetFullPath(Path.Combine(GetCurrentFileName(), $"../../../../{pathEnd}")).Replace(@"\", "/");
-            return "Assets/" + basePath.Split(new string[1] { "/Assets/" }, StringSplitOptions.None)[1];
+            string basePath = Path.GetFullPath(Path.Combine(GetCurrentFileName(), $"../../../../{pathEnd}")).Replace(@"\", "/");;
+            
+            // Needed as otherwise the art gets a null ref in the package manager version.
+            if (Directory.Exists("Assets/Carter Games/Save Manager"))
+            {
+                return "Assets/" + basePath.Split(new string[1] { "/Assets/" }, StringSplitOptions.None)[1];
+            }
+            else
+            {
+                return "Art/" + basePath.Split(new string[1] { "/Art/" }, StringSplitOptions.None)[1];
+            }
         }
         
         


### PR DESCRIPTION
- Just a small hotfix, not worth a new release for something this minor.