### PR TITLE
Fix Unity stripping ISaveDataLocation classes in some cases

### DIFF
--- a/Code/Runtime/Data Storage/Data Locations/Save/SaveLocationLocalFile.cs
+++ b/Code/Runtime/Data Storage/Data Locations/Save/SaveLocationLocalFile.cs
@@ -15,12 +15,14 @@
  */
 
 using CarterGames.Assets.SaveManager.Helpers;
+using UnityEngine.Scripting;
 
 namespace CarterGames.Assets.SaveManager
 {
     /// <summary>
     /// Handles saving game data to a local file.
     /// </summary>
+    [Preserve]
     public sealed class SaveLocationLocalFile : ISaveDataLocation
     {
         /* ─────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/Code/Runtime/Data Storage/Data Locations/Save/SaveLocationPlayerPrefs.cs
+++ b/Code/Runtime/Data Storage/Data Locations/Save/SaveLocationPlayerPrefs.cs
@@ -14,11 +14,14 @@
  * If not, see <https://www.gnu.org/licenses/>. 
  */
 
+using UnityEngine.Scripting;
+
 namespace CarterGames.Assets.SaveManager
 {
     /// <summary>
     /// Handles saving game data to a player prefs.
     /// </summary>
+    [Preserve]
     public sealed class SaveLocationPlayerPrefs : ISaveDataLocation
     {
         /* ─────────────────────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
When using `SaveManager.SaveGame()`, this error can occur in runtime :

> [GetDefinedType]: Failed to generate type from stored data. If you have refactored the class selected, please reselect it to update the record.

It appears that with further research, the `LocationHandler` class is null revealing that there is no save location set (even through there is.) 
Seems like Unity strips (if enabled in Project Settings) the `ISaveDataLocation` classes for some reason. This is fixed by adding the `[Preserve]` decoration from `UnityEngine.Scripting`

I think it needs more testing because I couldn't reproduce this issue with Unity 6.4 (it's happening for my project in Unity 6.6 Alpha.) 
If this true in any versions of Unity, it should be documented as well to avoid confusions.