### PR TITLE
Fix automatic InitializeSaveManagerRuntimeSetup() at runtime

### DIFF
--- a/Code/Runtime/SaveManagerInitializer.cs
+++ b/Code/Runtime/SaveManagerInitializer.cs
@@ -38,15 +38,15 @@ namespace CarterGames.Assets.SaveManager
         /// Raises when the save manager is initialized.
         /// </summary>
         public static Evt InitializedEvt = new Evt();
-        
+
         /* ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
         |   Methods
         ───────────────────────────────────────────────────────────────────────────────────────────────────────────── */
-        
+
         /// <summary>
         /// Runs Save Manager initialization when called.
         /// </summary>
-        [RuntimeInitializeOnLoadMethod]
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterAssembliesLoaded)]
         public static void InitializeSaveManagerRuntimeSetup()
         {
             if (IsInitialized) return;


### PR DESCRIPTION
`InitializeSaveManagerRuntimeSetup()` is normally executed when the first scene were loaded. It forces users to use `LoadGame()` if they need data at the beginning of this first scene even if it should be automatic.

Adding `RuntimeInitializeLoadType.AfterAssembliesLoaded` ensure that this method is runned just after SaveManager startup.