### PR TITLE
Assembly improvement

### DIFF
--- a/Code/Runtime/Save Data/Objects/SaveObjectController.cs
+++ b/Code/Runtime/Save Data/Objects/SaveObjectController.cs
@@ -148,8 +148,13 @@ namespace CarterGames.Assets.SaveManager
             AllGlobalSaveObjects = new List<SaveObject>();
             AllGlobalSaveValues = new Dictionary<SaveObject, List<SaveValueBase>>();
 
-            var objTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(x => x.GetTypes())
+#if UNITY_6000_0_OR_NEWER
+            var assemblies = UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+#else
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+#endif
+
+            var objTypes = assemblies.SelectMany(x => x.GetTypes())
                 .Where(x => x.IsClass && typeof(SaveObject).IsAssignableFrom(x) && !x.IsAbstract && x.FullName != typeof(SaveObject).FullName)
                 .Select(type => (SaveObject)ScriptableObject.CreateInstance(type))
                 .Select(t => t.GetType())

--- a/Shared Systems/Runtime/Helpers/AssemblyClassDef.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyClassDef.cs
@@ -118,9 +118,25 @@ namespace CarterGames.Shared.SaveManager
 			
 			try
 			{
-				return AssemblyHelper.GetClassesOfType<T>(false).FirstOrDefault(t =>
-					t.GetType().Assembly.FullName == Assembly && t.GetType().FullName == Type);
-			}
+                // We try first to resolve the type with his name :
+                // https://stackoverflow.com/questions/1825147/type-gettypenamespace-a-b-classname-returns-null
+                string assemblyQualifiedName = $"{Type}, {Assembly}";
+                Type targetType = System.Type.GetType(assemblyQualifiedName);
+
+                // If it failed, we use the fallback (without instantiation.)
+                if (targetType == null)
+                {
+                    targetType = AssemblyHelper.GetClassesNamesOfType<T>(false)
+                        .FirstOrDefault(t => t.Assembly.FullName == Assembly && t.FullName == Type);
+                }
+
+                if (targetType != null)
+                {
+                    return (T)Activator.CreateInstance(targetType);
+                }
+
+				return default;
+            }
 #pragma warning disable
 			catch (Exception e)
 			{

--- a/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
@@ -37,7 +37,7 @@ namespace CarterGames.Shared.SaveManager
         |   Fields
         ───────────────────────────────────────────────────────────────────────────────────────────────────────────── */
         
-        private static Assembly[] audioManagerAssemblies;
+        private static Assembly[] _cachedAssemblies;
         
         /* ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
         |   Properties
@@ -46,13 +46,13 @@ namespace CarterGames.Shared.SaveManager
         /// <summary>
         /// Gets all the cart assemblies to use when checking in internally only.
         /// </summary>
-        private static IEnumerable<Assembly> AudioManagerAssemblies
+        private static IEnumerable<Assembly> CachedAssemblies
         {
             get
             {
-                if (audioManagerAssemblies != null) return audioManagerAssemblies;
-                audioManagerAssemblies = GetAssemblies();
-                return audioManagerAssemblies;
+                if (_cachedAssemblies != null) return _cachedAssemblies;
+                _cachedAssemblies = GetAssemblies();
+                return _cachedAssemblies;
             }
         }
 
@@ -82,7 +82,7 @@ namespace CarterGames.Shared.SaveManager
         /// <returns>The total in the project.</returns>
         public static int CountClassesOfType<T>(bool internalCheckOnly = true)
         {
-            var assemblies = internalCheckOnly ? AudioManagerAssemblies : AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
                 
             return assemblies.SelectMany(x => x.GetTypes())
                 .Count(x => x.IsClass && typeof(T).IsAssignableFrom(x));
@@ -110,7 +110,7 @@ namespace CarterGames.Shared.SaveManager
         /// <returns>All the implementations of the entered class.</returns>
         public static IEnumerable<T> GetClassesOfType<T>(bool internalCheckOnly = true)
         {
-            var assemblies = internalCheckOnly ? AudioManagerAssemblies : AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
 
             return assemblies.SelectMany(x => x.GetTypes())
                 .Where(x => x.IsClass && typeof(T).IsAssignableFrom(x) && !x.IsAbstract && x.FullName != typeof(T).FullName)
@@ -126,7 +126,7 @@ namespace CarterGames.Shared.SaveManager
         /// <returns>All the implementations of the entered class.</returns>
         public static IEnumerable<Type> GetClassesNamesOfType<T>(bool internalCheckOnly = true)
         {
-            var assemblies = internalCheckOnly ? AudioManagerAssemblies : AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
 
             return assemblies.SelectMany(x => x.GetTypes())
                 .Where(x => x.IsClass && typeof(T).IsAssignableFrom(x) && x.FullName != typeof(T).FullName);

--- a/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
@@ -36,13 +36,19 @@ namespace CarterGames.Shared.SaveManager
         /* ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
         |   Fields
         ───────────────────────────────────────────────────────────────────────────────────────────────────────────── */
-        
+
+        /// <summary>
+        /// It is intended to use this cache to avoid the use
+        /// of <see cref="Assembly.GetTypes"/> in each call.
+        /// </summary>
+        private static readonly Dictionary<Type, List<Type>> TypeCache = new();
+
         private static Assembly[] _cachedAssemblies;
-        
+
         /* ─────────────────────────────────────────────────────────────────────────────────────────────────────────────
         |   Properties
         ───────────────────────────────────────────────────────────────────────────────────────────────────────────── */
-        
+
         /// <summary>
         /// Gets all the cart assemblies to use when checking in internally only.
         /// </summary>
@@ -82,10 +88,7 @@ namespace CarterGames.Shared.SaveManager
         /// <returns>The total in the project.</returns>
         public static int CountClassesOfType<T>(bool internalCheckOnly = true)
         {
-            var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
-                
-            return assemblies.SelectMany(x => x.GetTypes())
-                .Count(x => x.IsClass && typeof(T).IsAssignableFrom(x));
+            return GetClassesNamesOfType<T>(internalCheckOnly).Count();
         }
         
         
@@ -110,14 +113,11 @@ namespace CarterGames.Shared.SaveManager
         /// <returns>All the implementations of the entered class.</returns>
         public static IEnumerable<T> GetClassesOfType<T>(bool internalCheckOnly = true)
         {
-            var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
-
-            return assemblies.SelectMany(x => x.GetTypes())
-                .Where(x => x.IsClass && typeof(T).IsAssignableFrom(x) && !x.IsAbstract && x.FullName != typeof(T).FullName)
+            return GetClassesNamesOfType<T>(internalCheckOnly)
                 .Select(type => (T)Activator.CreateInstance(type));
         }
-        
-        
+
+
         /// <summary>
         /// Gets all the classes of the entered type in the project.
         /// </summary>
@@ -126,13 +126,27 @@ namespace CarterGames.Shared.SaveManager
         /// <returns>All the implementations of the entered class.</returns>
         public static IEnumerable<Type> GetClassesNamesOfType<T>(bool internalCheckOnly = true)
         {
+            Type targetType = typeof(T);
+
+            // We don't need to search in the project / assembly if we already know the type.
+            if (TypeCache.TryGetValue(targetType, out List<Type> cachedTypes))
+                return cachedTypes;
+
             var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
 
-            return assemblies.SelectMany(x => x.GetTypes())
-                .Where(x => x.IsClass && typeof(T).IsAssignableFrom(x) && x.FullName != typeof(T).FullName);
+            // Searching all the implementation of the class
+            var foundTypes = assemblies
+                .SelectMany(x => x.GetTypes())
+                .Where(x => x.IsClass && targetType.IsAssignableFrom(x) && x != targetType)
+                .ToList();
+
+            // Caching for later
+            TypeCache[targetType] = foundTypes;
+
+            return foundTypes;
         }
-        
-        
+
+
         /// <summary>
         /// Gets all the classes of the entered type in the project.
         /// </summary>

--- a/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
@@ -138,7 +138,8 @@ namespace CarterGames.Shared.SaveManager
             // Searching all the implementation of the class
             var foundTypes = assemblies
                 .SelectMany(x => x.GetTypes())
-                .Where(x => x.IsClass && targetType.IsAssignableFrom(x) && x != targetType)
+                .Where(x => x.IsClass && !x.IsAbstract && !x.ContainsGenericParameters 
+                    && targetType.IsAssignableFrom(x) && x != targetType)
                 .ToList();
 
             // Caching for later

--- a/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
@@ -132,8 +132,13 @@ namespace CarterGames.Shared.SaveManager
             if (TypeCache.TryGetValue(targetType, out List<Type> cachedTypes))
                 return cachedTypes;
 
-            var assemblies = internalCheckOnly ? CachedAssemblies 
+#if UNITY_6000_0_OR_NEWER
+            var assemblies = internalCheckOnly ? CachedAssemblies
                 : UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+#else
+            var assemblies = internalCheckOnly ? CachedAssemblies
+                : AppDomain.CurrentDomain.GetAssemblies();
+#endif
 
             // Searching all the implementation of the class
             var foundTypes = assemblies

--- a/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
@@ -132,7 +132,8 @@ namespace CarterGames.Shared.SaveManager
             if (TypeCache.TryGetValue(targetType, out List<Type> cachedTypes))
                 return cachedTypes;
 
-            var assemblies = internalCheckOnly ? CachedAssemblies : AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = internalCheckOnly ? CachedAssemblies 
+                : UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
 
             // Searching all the implementation of the class
             var foundTypes = assemblies

--- a/Shared Systems/Runtime/Helpers/Per Project/ProjectAssemblyDefinition.cs
+++ b/Shared Systems/Runtime/Helpers/Per Project/ProjectAssemblyDefinition.cs
@@ -27,31 +27,18 @@ namespace CarterGames.Shared.SaveManager
 {
     public static class ProjectAssemblyDefinition
     {
-        public static Assembly[] ProjectEditorAssemblies
+        public static Assembly[] ProjectEditorAssemblies { get; } = new Assembly[]
         {
-            get
-            {
-                return new Assembly[]
-                {
-                    Assembly.Load("CarterGames.SaveManager.Editor"),
-                    Assembly.Load("CarterGames.SaveManager.Runtime"),
-                    Assembly.Load("CarterGames.Shared.SaveManager.Editor"),
-                    Assembly.Load("CarterGames.Shared.SaveManager")
-                };
-            }
-        }
-        
-        
-        public static Assembly[] ProjectRuntimeAssemblies
+            Assembly.Load("CarterGames.SaveManager.Editor"),
+            Assembly.Load("CarterGames.SaveManager.Runtime"),
+            Assembly.Load("CarterGames.Shared.SaveManager.Editor"),
+            Assembly.Load("CarterGames.Shared.SaveManager")
+        };
+
+        public static Assembly[] ProjectRuntimeAssemblies { get; } = new Assembly[]
         {
-            get
-            {
-                return new Assembly[]
-                {
-                    Assembly.Load("CarterGames.SaveManager.Runtime"),
-                    Assembly.Load("CarterGames.Shared.SaveManager")
-                };
-            }
-        }
+            Assembly.Load("CarterGames.SaveManager.Runtime"),
+            Assembly.Load("CarterGames.Shared.SaveManager")
+        };
     }
 }

--- a/Shared Systems/Runtime/Helpers/Per Project/ProjectAssemblyDefinition.cs
+++ b/Shared Systems/Runtime/Helpers/Per Project/ProjectAssemblyDefinition.cs
@@ -27,6 +27,7 @@ namespace CarterGames.Shared.SaveManager
 {
     internal static class ProjectAssemblyDefinition
     {
+#if UNITY_EDITOR
         public static Assembly[] ProjectEditorAssemblies { get; } = new Assembly[]
         {
             Assembly.Load("CarterGames.SaveManager.Editor"),
@@ -34,11 +35,12 @@ namespace CarterGames.Shared.SaveManager
             Assembly.Load("CarterGames.Shared.SaveManager.Editor"),
             Assembly.Load("CarterGames.Shared.SaveManager")
         };
-
+#else
         public static Assembly[] ProjectRuntimeAssemblies { get; } = new Assembly[]
         {
             Assembly.Load("CarterGames.SaveManager.Runtime"),
             Assembly.Load("CarterGames.Shared.SaveManager")
         };
+#endif
     }
 }

--- a/Shared Systems/Runtime/Helpers/Per Project/ProjectAssemblyDefinition.cs
+++ b/Shared Systems/Runtime/Helpers/Per Project/ProjectAssemblyDefinition.cs
@@ -25,7 +25,7 @@ using System.Reflection;
 
 namespace CarterGames.Shared.SaveManager
 {
-    public static class ProjectAssemblyDefinition
+    internal static class ProjectAssemblyDefinition
     {
         public static Assembly[] ProjectEditorAssemblies { get; } = new Assembly[]
         {


### PR DESCRIPTION
Improves assembly scan and code by...

- Speeding up initialization for editor / runtime when searching for implementations of a type (especially if it searches in entire project each time.)
- Avoiding assemblies loading each time it scans the project.
- Integrating Unity 6.X changes.
- Changing a badly name variable (copy paste ?)

It should also _slighty_ improve `SaveGame()` and `LoadGame()`.

Those changes are quite critical so let me know if you have a question or if you noticed a bug. I tested it on my end and there's nothing alarming so far.