### PR TITLE
:package:  3.0.8 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.8] - 2026-06-21
+
+### Fixed
+- Fixed an issue where some settings in the asset do not save changes when they are edited by the user [[KI-26](https://cartergames.notion.site/Some-settings-do-not-save-in-the-settings-provider-374f72ed3eaf804ebf60e2745806d3b1)].
+- Fixed an issue reported by a user where the asset would not compile in Unity 6.0 > 6.3 versions due to an API change in a contribution [[KI-27](https://cartergames.notion.site/Compile-issue-with-Unity-6-6-3-x-386f72ed3eaf803fa80bf8e0d0553769)].
+
 ## [3.0.7] - 2026-05-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue where some settings in the asset do not save changes when they are edited by the user [[KI-26](https://cartergames.notion.site/Some-settings-do-not-save-in-the-settings-provider-374f72ed3eaf804ebf60e2745806d3b1)].
-- Fixed an issue reported by a user where the asset would not compile in Unity 6.0 > 6.3 versions due to an API change in a contribution [[KI-27](https://cartergames.notion.site/Compile-issue-with-Unity-6-6-3-x-386f72ed3eaf803fa80bf8e0d0553769)].
+- Fixed an issue reported by a user where the asset would not compile in Unity 6.0 > 6.3 versions due to an API change in a contribution [[KI-27](https://cartergames.notion.site/Compile-issue-with-Unity-6-6-3-x-386f72ed3eaf803fa80bf8e0d0553769)] [[GIT-ISS#42](https://github.com/CarterGames/SaveManager/issues/42)].
 
 ## [3.0.7] - 2026-05-24
 

--- a/Code/Runtime/Prefs/SaveManagerPrefs.cs
+++ b/Code/Runtime/Prefs/SaveManagerPrefs.cs
@@ -131,6 +131,7 @@ namespace CarterGames.Assets.SaveManager
         private static void Internal_SetKey<T>(string key, string value)
         {
             PlayerPrefs.SetString(Internal_GetKey(key), value);
+            PlayerPrefs.Save();
         }
     }
 }

--- a/Code/Runtime/Save Data/Objects/SaveObjectController.cs
+++ b/Code/Runtime/Save Data/Objects/SaveObjectController.cs
@@ -148,7 +148,7 @@ namespace CarterGames.Assets.SaveManager
             AllGlobalSaveObjects = new List<SaveObject>();
             AllGlobalSaveValues = new Dictionary<SaveObject, List<SaveValueBase>>();
 
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             var assemblies = UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
 #else
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();

--- a/Shared Systems/Editor/Asset Info/AssetVersionData.cs
+++ b/Shared Systems/Editor/Asset Info/AssetVersionData.cs
@@ -30,7 +30,7 @@ namespace CarterGames.Shared.SaveManager.Editor
         /// <summary>
         /// The version number of the asset.
         /// </summary>
-        public static string VersionNumber => "3.0.7";
+        public static string VersionNumber => "3.0.8";
         
         
         /// <summary>
@@ -39,6 +39,6 @@ namespace CarterGames.Shared.SaveManager.Editor
         /// <remarks>
         /// Asset owner is in the UK, so its Y/M/D format.
         /// </remarks>
-        public static string ReleaseDate => "2026/05/24";
+        public static string ReleaseDate => "2026/06/21";
     }
 }

--- a/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
+++ b/Shared Systems/Runtime/Helpers/AssemblyHelper.cs
@@ -111,7 +111,7 @@ namespace CarterGames.Shared.SaveManager
             // We don't need to search in the project / assembly if we already know the type.
             if (TypeCache.TryGetValue(targetType, out List<Type> cachedTypes)) return cachedTypes;
 
-#if UNITY_6000_0_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             var assemblies = internalCheckOnly ? CachedAssemblies
                 : UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
 #else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "games.carter.savemanager",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "displayName": "Save Manager",
   "description": "A free, modular, scriptable object based local save system for Unity.",
   "unity": "2020.3",


### PR DESCRIPTION
### Fixed
- Fixed an issue where some settings in the asset do not save changes when they are edited by the user [[KI-26](https://cartergames.notion.site/Some-settings-do-not-save-in-the-settings-provider-374f72ed3eaf804ebf60e2745806d3b1)].
- Fixed an issue reported by a user where the asset would not compile in Unity 6.0 > 6.3 versions due to an API change in a contribution [[KI-27](https://cartergames.notion.site/Compile-issue-with-Unity-6-6-3-x-386f72ed3eaf803fa80bf8e0d0553769)] [[GIT-ISS#42](https://github.com/CarterGames/SaveManager/issues/42)].